### PR TITLE
feat : 도커 파일 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,16 @@
-
 # 1단계: 빌드 스테이지
-FROM --platform=linux/amd64 gradle:8.5-jdk21-alpine AS builder
+FROM --platform=linux/amd64 eclipse-temurin:21-jdk AS builder
 
 WORKDIR /app
 COPY . .
 
 RUN chmod +x ./gradlew
-
-# Gradle 캐시 최적화 & JAR 만들기
 RUN ./gradlew clean bootJar --no-daemon
 
 # 2단계: 런타임 스테이지
 FROM --platform=linux/amd64 eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
-
-# builder에서 jar만 복사
 COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces the Gradle builder image with Eclipse Temurin JDK, builds via the Gradle wrapper, and keeps the alpine Temurin runtime while copying the built jar.
> 
> - **Docker**
>   - **Builder stage**: Use `eclipse-temurin:21-jdk` instead of `gradle:8.5-jdk21-alpine`; build with `./gradlew clean bootJar`.
>   - **Runtime stage**: Keep `eclipse-temurin:21-jdk-alpine`; copy `build/libs/*.jar` to `app.jar` and run with `java -jar`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2eca261dbd8c8519311079658b308b71c2467a8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->