### PR TITLE
feat : 도커 파일 수정2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
 # 1단계: 빌드 스테이지
-FROM --platform=linux/amd64 eclipse-temurin:21-jdk AS builder
+FROM --platform=linux/amd64 gradle:8.5-jdk21-alpine AS builder
 
 WORKDIR /app
 COPY . .
 
 RUN chmod +x ./gradlew
+
+# Gradle 캐시 최적화 & JAR 만들기
 RUN ./gradlew clean bootJar --no-daemon
 
 # 2단계: 런타임 스테이지
 FROM --platform=linux/amd64 eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
+
+# builder에서 jar만 복사
 COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the Docker builder stage to Gradle 8.5 JDK21 Alpine and finalizes a multi-stage build that copies the built JAR into a Temurin Alpine runtime.
> 
> - **Docker**:
>   - **Builder stage**: Change base image to `gradle:8.5-jdk21-alpine`, ensure `gradlew` is executable, and build JAR via `./gradlew clean bootJar --no-daemon`.
>   - **Runtime stage**: Keep `eclipse-temurin:21-jdk-alpine`, copy `build/libs/*.jar` to `app.jar`, expose `8080`, and set `ENTRYPOINT` to run the JAR.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb250afbd4bb84b819fc2b58f8754dd33a435c6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->