### PR TITLE
feat : 도커 파일 수정 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-# 1단계: 빌드 스테이지 (무조건 성공하는 조합)
-FROM --platform=linux/amd64 gradle:8.5-jdk21 AS builder
+# 1단계: 빌드 스테이지 (Java 17)
+FROM eclipse-temurin:17-jdk AS builder
 
 WORKDIR /app
 COPY . .
 
-RUN  chmod +x ./gradlew
-RUN  ./gradlew clean bootJar --no-daemon
+RUN chmod +x ./gradlew
+RUN ./gradlew clean bootJar --no-daemon
 
-# 2단계: 런타임 스테이지
-FROM --platform=linux/amd64 eclipse-temurin:21-jdk-alpine
+# 2단계: 런타임 스테이지 (Java 17 또는 21 둘 다 가능)
+FROM eclipse-temurin:17-jdk-alpine
 
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrates Dockerfile to Eclipse Temurin Java 17 for build/runtime, removes platform pinning, and keeps the Gradle bootJar flow.
> 
> - **Dockerfile**:
>   - **Base images**: Use `eclipse-temurin:17-jdk` for builder and `eclipse-temurin:17-jdk-alpine` for runtime (replacing Java 21/amd64-specific images).
>   - **Simplification**: Remove `--platform=linux/amd64` flags; retain `./gradlew clean bootJar --no-daemon` and copy built JAR to `app.jar`.
>   - **Runtime**: Keep `EXPOSE 8080` and `ENTRYPOINT ["java", "-jar", "app.jar"]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a83a2588ccb4775a4a3a0c3f417cc15827b3acf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->