### PR TITLE
fix : CI/CD 에러 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-# 1단계: 빌드 스테이지 (무조건 성공하는 조합)
-FROM --platform=linux/amd64 gradle:8.5-jdk21 AS builder
+# 1단계: 빌드 스테이지 (Java 17)
+FROM eclipse-temurin:17-jdk AS builder
 
 WORKDIR /app
 COPY . .
 
-RUN  chmod +x ./gradlew
-RUN  ./gradlew clean bootJar --no-daemon
+RUN chmod +x ./gradlew
+RUN ./gradlew clean bootJar --no-daemon
 
-# 2단계: 런타임 스테이지
-FROM --platform=linux/amd64 eclipse-temurin:21-jdk-alpine
+# 2단계: 런타임 스테이지 (Java 17 또는 21 둘 다 가능)
+FROM eclipse-temurin:17-jdk-alpine
 
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar


### PR DESCRIPTION
1. Java Jdk version 에러
로컬 jdk는 17이였지만  Github actions base image의 jdk 버전이 21로 실행중이였다.

따라서 github actions jdk 베이스 이미지를 17로 변경

