### PR TITLE
[Hotfix] Gemini API 글로벌 rate limit 적용

### DIFF
--- a/src/main/java/BookPick/mvp/domain/curation/util/gemini/client/GeminiClient.java
+++ b/src/main/java/BookPick/mvp/domain/curation/util/gemini/client/GeminiClient.java
@@ -3,6 +3,8 @@ package BookPick.mvp.domain.curation.util.gemini.client;
 
 
 import BookPick.mvp.domain.curation.util.gemini.GeminiErrorException;
+import BookPick.mvp.domain.curation.util.gemini.enums.GeminiErrorCode;
+import BookPick.mvp.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -10,15 +12,24 @@ import org.springframework.http.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 @Component
 @RequiredArgsConstructor
 public class GeminiClient {
+
+    private static final int MAX_REQUESTS_PER_MINUTE = 30;
+
+    private final AtomicInteger requestCount = new AtomicInteger(0);
+    private final AtomicLong windowStart = new AtomicLong(System.currentTimeMillis());
 
     private final GeminiConfig config;
     private final RestTemplate restTemplate = new RestTemplate();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     public String callGemini(String systemInstruction, String userContent) {
+        checkRateLimit();
         try {
             String url = config.getApiUrl() + "?key=" + config.getApiKey();
 
@@ -63,6 +74,21 @@ public class GeminiClient {
 
         } catch (Exception e) {
             throw new GeminiErrorException();
+        }
+    }
+
+    private void checkRateLimit() {
+        long now = System.currentTimeMillis();
+        long windowStartTime = windowStart.get();
+
+        // 1분 경과 시 카운터 리셋
+        if (now - windowStartTime >= 60_000) {
+            requestCount.set(0);
+            windowStart.set(now);
+        }
+
+        if (requestCount.incrementAndGet() > MAX_REQUESTS_PER_MINUTE) {
+            throw new BusinessException(GeminiErrorCode.GEMINI_API_RATE_LIMITED);
         }
     }
 }

--- a/src/main/java/BookPick/mvp/domain/curation/util/gemini/enums/GeminiErrorCode.java
+++ b/src/main/java/BookPick/mvp/domain/curation/util/gemini/enums/GeminiErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum GeminiErrorCode implements ErrorCodeInterface {
 
-    GEMINI_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Gemini API 호출에 실패했습니다.");
+    GEMINI_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Gemini API 호출에 실패했습니다."),
+    GEMINI_API_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.");
 
 
 


### PR DESCRIPTION
## 개요
Gemini API 과금 공격 방어를 위한 글로벌 rate limit 적용

## 변경 내용
- GeminiClient에 분당 최대 30회 호출 제한 추가
- 초과 시 429 (Too Many Requests) 응답 반환
- AtomicInteger / AtomicLong 기반 동시성 안전 처리

## 배경
- 유저별 캐싱(10분 TTL)은 이미 적용되어 있으나, 다수의 신규 유저가 동시에 요청하는 경우 Gemini API 과금이 발생할 수 있음
- Tier 1 기준 분당 150~300 RPM 가능하지만, MVP 단계에서 보수적으로 30 RPM으로 제한

## 확인 사항
- [x] rate limit 초과 시 429 응답 정상 반환
- [x] 제한 내 요청은 정상 처리