### PR TITLE
feat[b7f58dc] prevent null login_password on oauth signup

### DIFF
--- a/src/main/java/BookPick/mvp/domain/auth/dto/LoginReq.java
+++ b/src/main/java/BookPick/mvp/domain/auth/dto/LoginReq.java
@@ -5,4 +5,5 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 // -- Login --
-public record LoginReq(@NotBlank @Email String email, @Size(min = 8, max = 72) String password) {}
+public record LoginReq(
+        @NotBlank @Email String email, @NotBlank @Size(min = 8, max = 72) String password) {}

--- a/src/main/java/BookPick/mvp/domain/auth/dto/SignReq.java
+++ b/src/main/java/BookPick/mvp/domain/auth/dto/SignReq.java
@@ -5,4 +5,5 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 // -- SignUp --
-public record SignReq(@NotBlank @Email String email, @Size(min = 8, max = 72) String password) {}
+public record SignReq(
+        @NotBlank @Email String email, @NotBlank @Size(min = 8, max = 72) String password) {}

--- a/src/main/java/BookPick/mvp/domain/user/entity/User.java
+++ b/src/main/java/BookPick/mvp/domain/user/entity/User.java
@@ -27,8 +27,8 @@ public class User {
     @Email(message = "올바른 이메일 형식이여야 합니다.")
     private String email; // 로그인 ID, 고유
 
-    @Column(name = "login_password", nullable = true, length = 255)
-    private String password; // 비밀번호 해시 (OAuth 사용자는 null)
+    @Column(name = "login_password", nullable = false, length = 255)
+    private String password; // 비밀번호 해시
 
     @Column(name = "provider", length = 20)
     private String provider; // OAuth 제공자 (kakao, google 등)


### PR DESCRIPTION
## Summary
- prevent OAuth 신규 가입에서 login_password NULL 저장
- SignReq/LoginReq password에 NotBlank 추가
- User 엔티티 login_password nullable=false로 정렬

## Linked Issue
Closes #107

## Test
- OAuth 신규 가입 시 login_password NULL insert 방지 확인
- DTO 유효성으로 null/blank password 요청 차단